### PR TITLE
Avoid leaving shared key in memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,23 @@ exclude = [".github/"]
 
 [features]
 vendored = ["dbus/vendored", "openssl?/vendored"]
-crypto-rust = ["dep:aes", "dep:block-padding", "dep:cbc", "dep:fastrand", "dep:hkdf", "dep:sha2"]
+crypto-rust = [
+  "dep:aes",
+  "dep:block-padding",
+  "dep:cbc",
+  "dep:fastrand",
+  "dep:hkdf",
+  "dep:sha2",
+]
 crypto-openssl = ["dep:fastrand", "dep:openssl"]
 
 [dependencies]
 aes = { version = "0.8", optional = true }
 block-padding = { version = "0.3", features = ["std"], optional = true }
-cbc = { version = "0.1", features = ["block-padding", "alloc"], optional = true }
+cbc = { version = "0.1", features = [
+  "block-padding",
+  "alloc",
+], optional = true }
 dbus = "0.9"
 fastrand = { version = "2.3", optional = true }
 futures-util = "0.3"
@@ -29,6 +39,7 @@ num = "0.4"
 once_cell = "1"
 openssl = { version = "0.10.55", optional = true }
 sha2 = { version = "0.10", optional = true }
+zeroize = { version = "1.8.1", features = ["derive"] }
 
 [dev-dependencies]
 test-with = { version = "0.12", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,23 +14,13 @@ exclude = [".github/"]
 
 [features]
 vendored = ["dbus/vendored", "openssl?/vendored"]
-crypto-rust = [
-  "dep:aes",
-  "dep:block-padding",
-  "dep:cbc",
-  "dep:fastrand",
-  "dep:hkdf",
-  "dep:sha2",
-]
+crypto-rust = ["dep:aes", "dep:block-padding", "dep:cbc", "dep:fastrand", "dep:hkdf", "dep:sha2"]
 crypto-openssl = ["dep:fastrand", "dep:openssl"]
 
 [dependencies]
 aes = { version = "0.8", optional = true }
 block-padding = { version = "0.3", features = ["std"], optional = true }
-cbc = { version = "0.1", features = [
-  "block-padding",
-  "alloc",
-], optional = true }
+cbc = { version = "0.1", features = ["block-padding", "alloc"], optional = true }
 dbus = "0.9"
 fastrand = { version = "2.3", optional = true }
 futures-util = "0.3"

--- a/src/session.rs
+++ b/src/session.rs
@@ -19,13 +19,11 @@ use dbus::{
     blocking::{Connection, Proxy},
     Path,
 };
-
+use zeroize::ZeroizeOnDrop;
 use crate::Error;
 
 #[cfg(all(feature = "crypto-rust", feature = "crypto-openssl"))]
 compile_error!("You cannot specify both feature \"crypto-rust\" and feature \"crypto-openssl\"");
-
-use zeroize::ZeroizeOnDrop;
 
 /// The algorithms that can be used for encryption-in-transit.
 ///

--- a/src/session.rs
+++ b/src/session.rs
@@ -14,13 +14,14 @@
 // 6. Format Secret: encode the secret value for the value field in secret struct.
 //      This encoding uses the aes_key from the associated Session.
 
-use crate::Error;
 use dbus::{
     arg::{RefArg, Variant},
     blocking::{Connection, Proxy},
     Path,
 };
 use zeroize::ZeroizeOnDrop;
+
+use crate::Error;
 
 #[cfg(all(feature = "crypto-rust", feature = "crypto-openssl"))]
 compile_error!("You cannot specify both feature \"crypto-rust\" and feature \"crypto-openssl\"");

--- a/src/session.rs
+++ b/src/session.rs
@@ -14,13 +14,13 @@
 // 6. Format Secret: encode the secret value for the value field in secret struct.
 //      This encoding uses the aes_key from the associated Session.
 
+use crate::Error;
 use dbus::{
     arg::{RefArg, Variant},
     blocking::{Connection, Proxy},
     Path,
 };
 use zeroize::ZeroizeOnDrop;
-use crate::Error;
 
 #[cfg(all(feature = "crypto-rust", feature = "crypto-openssl"))]
 compile_error!("You cannot specify both feature \"crypto-rust\" and feature \"crypto-openssl\"");
@@ -45,7 +45,7 @@ pub enum EncryptionType {
 #[derive(ZeroizeOnDrop)]
 pub(crate) struct EncryptedSecret {
     #[zeroize(skip)]
-    path: Path<'static>,     // the session path
+    path: Path<'static>, // the session path
     salt: Vec<u8>,           // the salt for the encrypted data
     data: Vec<u8>,           // the encrypted data
     pub(crate) mime: String, // the mime type of the decrypted data


### PR DESCRIPTION
this first PR just handles the case where encryption is enabled.
using `ZeroizeOnDrop` on both `EncryptedSecret` and `Session` in order to avoid leaving the shared key in memory.

I still need to figure out a way to verify the shared key is indeed not in memory anymore after dropping the session. But I'm confident it does not.
I'll probably handle this with some **non-buffered** debug logs + gdb memory dump.
would probably be nice to have tests (both in dbus-secret-service and keyring-rs) to make sure no regression are possible.

note that even with these changes, I am still able to find my password when using `EncryptionType::Plain` but this **may** be because of the dbus crate implementation.

Furthermore I'd highly suggest NOT to allow the use of `Plain` mode. because you can see everytying using `dbus-monitor`
If you still insist allowing Plain mode, I'd highly advise adding some big fat warning saying this is wrong. And probably making `EncryptionType::Dh` the default... in both dbus-secret-service and keyring-rs

Anyway, investigation is ongoing to verify my assumptions about dbus crate being the culprit when using `EncryptionType::Plain`

If that is the case, we won't be able to do much as dbus crate owners will tell you to encrypt the data. and they'd be right !